### PR TITLE
Use more suitable signal for entering coordinates (closes #4)

### DIFF
--- a/grid_ref.py
+++ b/grid_ref.py
@@ -269,7 +269,7 @@ class OSGBWidget(QFrame):
 
         iface.mapCanvas().xyCoordinates.connect(self.trackCoords)
 
-        self.editCoords.editingFinished.connect(self.setCoords)
+        self.editCoords.returnPressed.connect(self.setCoords)
 
     def trackCoords(self, pt):
         # dynamically determine the most sensible precision for the given scale


### PR DESCRIPTION
This avoids repeated error messages on invalid coordinates.
On Windows this may even lock up QGIS.